### PR TITLE
Remove 'vagrant' from magento2 cron entry

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,6 +5,6 @@ apt-get install -y ruby-compass
 gem install compass
 composer config --global process-timeout 2000
 /bin/bash /var/www/public/magento2/firstRun
-echo "*/5 * * * * vagrant php /var/www/public/magento2/bin/magento cron:run" >> mycron
+echo "*/5 * * * * /usr/bin/php /var/www/public/magento2/bin/magento cron:run" >> mycron
 crontab mycron
 rm mycron


### PR DESCRIPTION
The presence of the 'vagrant' at the beginning of the command didn't seem to work, it wasn't clear to us why it was there.

Thanks for this project!
