### PR TITLE
Add mount options for symlinks to work on windows hosts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
   elsif host =~ /mswin|mingw|cygwin/
     # Windows code via https://github.com/rdsubhas/vagrant-faster
     mem = `wmic computersystem Get TotalPhysicalMemory`.split[1].to_i / 1024
-    config.vm.synced_folder "./", "/var/www", type:"smb"
+    config.vm.synced_folder "./", "/var/www", type:"smb", mount_options: ["vers=3.02","mfsymlinks"]
   end
 
   mem = mem / 1024 / 4


### PR DESCRIPTION
Ran into an issue where symlinks did not work on vagrant with a windows host, the issue occurred during provision when modman tried to symlink Inchoo_PHP7. Adding mount options fixes the issue on my machine. Sending a PR to get your feedback if you think others may benefit from this. Otherwise feel free to comment and close.

Details of the errors:
==> default: Running provisioner: shell...
    default: cp: cannot create symbolic link '/var/www/public/magento1/shell/inchoo_php7_test.php': Operation not supported
    default: cp:
    default: cannot create symbolic link '/var/www/public/magento1/app/etc/modules/Inchoo_PHP7.xml'
    default: : Operation not supported
    default: cp:
    default: cannot create symbolic link '/var/www/public/magento1/app/code/local/Inchoo/PHP7'
    default: : Operation not supported
    default: cp:
    default: cannot create symbolic link '/var/www/public/magento1/app/code/local/Mage/Connect/Packager.php'
    default: : Operation not supported
    default: cp:
    default: cannot create symbolic link '/var/www/public/magento1/app/code/local/Mage/Core/Model/Resource/Session.php'
    default: : Operation not supported
    default: cp:
    default: cannot create symbolic link '/var/www/public/magento1/app/code/local/Mage/Sales/Model/Config/Ordered.php'
    default: : Operation not supported
